### PR TITLE
Genotype integration from VDJbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # set base image (host OS)
-FROM python:3.9
+FROM python:3.9.23
 
 # Install jq so we can process JSON
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y --fix-missing \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 FROM python:3.9
 
 # Install jq so we can process JSON
-RUN apt-get update && apt-get install jq -y
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y --fix-missing \
+    jq \
+    nano
 
 # https://stackoverflow.com/questions/53835198/integrating-python-poetry-with-docker
 ENV YOUR_ENV=${YOUR_ENV} \

--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,14 @@ adc-transform-repertoire-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
 
 adc-transform-chain-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
 	@echo ""
+	@echo "START: " `date`
+	@echo ""
 	@echo "Chain transform"
 	@echo ""
 	python3 adc_chain_transform.py $*
+	@echo ""
+	@echo "END: " `date`
+	@echo ""
 
 adc-transform-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
 	@echo ""
@@ -208,10 +213,19 @@ adc-transform-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
 	@echo ""
 
 adc-transform-repertoire: $(ADC_TRANSFORM_REPERTOIRE_TARGETS)
+	@echo ""
+	@echo "DONE"
+	@echo ""
 
 adc-transform-chain: $(ADC_TRANSFORM_CHAIN_TARGETS)
+	@echo ""
+	@echo "DONE"
+	@echo ""
 
 adc-transform: $(ADC_TRANSFORM_TARGETS)
+	@echo ""
+	@echo "DONE"
+	@echo ""
 
 adc-delete-snapshot:
 	rm -rf $(ADC_DATA)/adc_jsonl.snapshot

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 
 # AIRR Knowledge extract, transform, validate, load pipeline
 
-# docker should map these paths to the local host where the data resides
+# docker maps this path to the local host where the data resides
 AK_DATA=/ak_data
+
+# data import directories
 ADC_DATA=$(AK_DATA)/vdjserver-adc-cache
 IEDB_DATA=$(AK_DATA)/iedb
+VDJBASE_DATA=$(AK_DATA)/vdjbase
+
+# transformed data ready for DB load
 AK_DATA_LOAD=$(AK_DATA)/ak-data-load
 
+# TODO: studies are hard-coded, matching list in ak_schema_utils.py
 # study list for ADC rearrangements
 ADC_CACHE_LIST=2314581927515778580-242ac117-0001-012 \
     2531647238962745836-242ac114-0001-012 \
@@ -66,6 +72,8 @@ help:
 	@echo "Data Transform workflow"
 	@echo "  (run within docker)"
 	@echo "------------------------------------------------------------"
+	@echo "make ogrdb-transform    -- Transform OGRDB germlines"
+	@echo ""
 	@echo "make iedb-tcr           -- Transform IEDB TCR export file"
 	@echo "make iedb-bcr           -- Transform IEDB BCR export file"
 	@echo "make irad-bcr           -- Transform IRAD BCRs"
@@ -73,6 +81,8 @@ help:
 	@echo "make adc-transform           -- Transform ADC rearrangements for all studies"
 	@echo "make adc-transform-CACHE_ID  -- Transform ADC repertoires and rearrangements for study CACHE_ID"
 	@echo "make adc-copy                -- Copy transformed ADC data to DB load directory"
+	@echo ""
+	@echo "make vdjbase-transform       -- Transform VDJbase genotypes"
 	@echo "------------------------------------------------------------"
 	@echo ""
 	@echo "    Database Loads"
@@ -131,6 +141,10 @@ extract-vdjbase:
 # Data transform
 #
 
+# OGRDB transform
+ogrdb-transform:
+	@echo "Not implemented."
+
 # IEDB transform
 $(IEDB_DATA)/iedb_tsv/:
 	mkdir -p $@
@@ -181,6 +195,13 @@ adc-copy:
 	cp -rf $(ADC_DATA)/adc_jsonl $(AK_DATA_LOAD)/adc/
 	cp -rf $(ADC_DATA)/adc_tsv $(AK_DATA_LOAD)/adc/
 
+# VDJbase transform
+$(VDJBASE_DATA)/vdjbase_tsv/:
+	mkdir -p $@
+	mkdir -p $(VDJBASE_DATA)/vdjbase_jsonl/
+
+vdjbase-transform: ak_schema.py | $(VDJBASE_DATA)/vdjbase_tsv/
+	python3 vdjbase_metadata_transform.py vdjbase-2025-08-231-0001-012
 
 #
 # Ontology exports and loads

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,17 @@ help:
 	@echo ""
 	@echo "make import-clean       -- Remove generated files from data transform"
 	@echo "make load-clean         -- Remove generated files for DB load"
+	@echo "------------------------------------------------------------"
+	@echo ""
+	@echo "Data Extract workflow"
+	@echo "  (run within docker)"
+	@echo "------------------------------------------------------------"
+	@echo "make extract-ogrdb      -- Extract data from OGRDB"
+	@echo "make extract-iedb       -- Extract data from IEDB"
+	@echo "make extract-adc        -- Extract data from VDJServer's ADC cache"
+	@echo "make extract-irad       -- Extract data from IRAD"
+	@echo "make extract-vdjbase    -- Extract data from VDJbase"
+	@echo "------------------------------------------------------------"
 	@echo ""
 	@echo "Data Transform workflow"
 	@echo "  (run within docker)"
@@ -62,6 +73,7 @@ help:
 	@echo "make adc-transform           -- Transform ADC rearrangements for all studies"
 	@echo "make adc-transform-CACHE_ID  -- Transform ADC repertoires and rearrangements for study CACHE_ID"
 	@echo "make adc-copy                -- Copy transformed ADC data to DB load directory"
+	@echo "------------------------------------------------------------"
 	@echo ""
 	@echo "    Database Loads"
 	@echo "  (run outside docker)"
@@ -77,7 +89,6 @@ help:
 	@echo ""
 	@echo "make load-adc-CACHE_ID  -- Load ADC data into airrkb for study CACHE_ID"
 	@echo "make load-adc-data      -- Load all ADC data into airrkb"
-	@echo ""
 	@echo "------------------------------------------------------------"
 	@echo ""
 
@@ -96,6 +107,25 @@ ak_schema.py: ak-schema/project/linkml/ak_schema.yaml
 
 list-adc-cache:
 	@echo $(ADC_CACHE_LIST)
+
+#
+# Data extraction
+#
+extract-ogrdb:
+	@echo "Not implemented."
+
+extract-iedb:
+	@echo "Not implemented."
+
+extract-adc:
+	@echo "Not implemented."
+
+extract-irad:
+	@echo "Not implemented."
+
+extract-vdjbase:
+	@echo "Downloading VDJbase data."
+	bash download_vdjbase_data.sh
 
 #
 # Data transform

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ ADC_CACHE_LIST=2314581927515778580-242ac117-0001-012 \
     6906582706313892331-242ac117-0001-012
 
 ADC_TRANSFORM_TARGETS := $(addprefix adc-transform-,$(ADC_CACHE_LIST))
+ADC_TRANSFORM_REPERTOIRE_TARGETS := $(addprefix adc-transform-repertoire-,$(ADC_CACHE_LIST))
+ADC_TRANSFORM_CHAIN_TARGETS := $(addprefix adc-transform-chain-,$(ADC_CACHE_LIST))
 ADC_LOAD_TARGETS := $(addprefix load-adc-,$(ADC_CACHE_LIST))
 
 # note: "help" MUST be the first target in the file, so
@@ -78,9 +80,14 @@ help:
 	@echo "make iedb-bcr           -- Transform IEDB BCR export file"
 	@echo "make irad-bcr           -- Transform IRAD BCRs"
 	@echo ""
-	@echo "make adc-transform           -- Transform ADC rearrangements for all studies"
-	@echo "make adc-transform-CACHE_ID  -- Transform ADC repertoires and rearrangements for study CACHE_ID"
-	@echo "make adc-copy                -- Copy transformed ADC data to DB load directory"
+	@echo "make adc-delete-snapshot                -- Delete snapshot of transformed ADC data"
+	@echo "make adc-snapshot                       -- Make snapshot of transformed ADC data"
+	@echo ""
+	@echo "make adc-transform                      -- Transform ADC rearrangements for all studies"
+	@echo "make adc-transform-CACHE_ID             -- Transform ADC repertoires and rearrangements for study CACHE_ID"
+	@echo "make adc-transform-repertoire-CACHE_ID  -- Transform ADC repertoires for study CACHE_ID"
+	@echo "make adc-transform-chain-CACHE_ID       -- Transform ADC rearrangements for study CACHE_ID"
+	@echo "make adc-copy                           -- Copy transformed ADC data to DB load directory"
 	@echo ""
 	@echo "make vdjbase-transform       -- Transform VDJbase genotypes"
 	@echo "------------------------------------------------------------"
@@ -173,6 +180,18 @@ $(ADC_DATA)/adc_tsv/:
 
 # ADC repertoire and rearrangement transform
 # manual targets for each study is not the best
+adc-transform-repertoire-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
+	@echo ""
+	@echo "Repertoire transform"
+	@echo ""
+	python3 adc_repertoire_transform.py $*
+
+adc-transform-chain-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
+	@echo ""
+	@echo "Chain transform"
+	@echo ""
+	python3 adc_chain_transform.py $*
+
 adc-transform-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
 	@echo ""
 	@echo "START: " `date`
@@ -188,7 +207,19 @@ adc-transform-%: ak_schema.py | $(ADC_DATA)/adc_tsv/
 	@echo "END: " `date`
 	@echo ""
 
+adc-transform-repertoire: $(ADC_TRANSFORM_REPERTOIRE_TARGETS)
+
+adc-transform-chain: $(ADC_TRANSFORM_CHAIN_TARGETS)
+
 adc-transform: $(ADC_TRANSFORM_TARGETS)
+
+adc-delete-snapshot:
+	rm -rf $(ADC_DATA)/adc_jsonl.snapshot
+	rm -rf $(ADC_DATA)/adc_tsv.snapshot
+
+adc-snapshot:
+	mv $(ADC_DATA)/adc_jsonl $(ADC_DATA)/adc_jsonl.snapshot
+	mv $(ADC_DATA)/adc_tsv $(ADC_DATA)/adc_tsv.snapshot
 
 adc-copy:
 	mkdir -p $(AK_DATA_LOAD)/adc

--- a/adc_repertoire_transform.py
+++ b/adc_repertoire_transform.py
@@ -1,24 +1,21 @@
 import dataclasses
 import click
-import csv
-import airr
-import os
 import sys
-import gzip
-import hashlib
-import itertools
-from dateutil.parser import parse
-
+import os
 from linkml_runtime.utils.schemaview import SchemaView
-from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, SchemaDefinition
-from linkml_runtime.dumpers import yaml_dumper, json_dumper, tsv_dumper
-
-from ak_schema import *
-from ak_schema_utils import *
+from ak_schema import AIRRKnowledgeCommons
+from ak_schema_utils import (
+    cache_list,
+    write_jsonl,
+    write_csv,
+    write_all_relationships,
+    adc_data_dir,
+    adc_cache_dir
+)
+from transform_airr_repertoires import transform_airr_repertoires
 
 ak_schema_view = SchemaView("ak-schema/project/linkml/ak_schema.yaml")
 
-#yaml_path = ak_load_dir + '/adc-repertoire.yaml'
 
 @click.command()
 @click.argument('cache_id')
@@ -29,212 +26,10 @@ def repertoire_transform(cache_id):
         print(f"Given cache id: {cache_id} is not in the study list")
         sys.exit(1)
 
-    study_cnt = 0
     study = cache_id
-
-    print('Processing study cache:', study)
-    container = AIRRKnowledgeCommons()
-
-    # Load the AIRR data
-    data = airr.read_airr(adc_cache_dir + '/' + study + '/repertoires.airr.json')
-
-    # loop through the repertoires
-    first = True
-    subjects = {}
-    arms = {}
-    samples = {}
-    for rep in data['Repertoire']:
-        print('Processing repertoire:', rep['repertoire_id'])
-
-        # create investigation object
-        if first:
-            if 'ImmuneCODE' in rep['study'].get('study_id'):
-                archival_id = rep['study'].get('study_id').replace(' ','')
-            else:
-                archival_id = rep['study'].get('study_id')
-
-            investigation = Investigation(
-                akc_id(),
-                name = rep['study'].get('study_title'),
-                description = rep['study'].get('study_description'),
-                archival_id = archival_id,
-                investigation_type = adc_ontology(rep['study']['study_type']),
-                inclusion_exclusion_criteria = rep['study'].get('inclusion_exclusion_criteria'),
-                release_date = to_datetime(rep['study'].get('adc_release_date')),
-                update_date = to_datetime(rep['study'].get('adc_update_date'))
-            )
-
-            # documents
-            if rep['study'].get('pub_ids') is not None:
-                if type(rep['study']['pub_ids']) == list:
-                    for r in rep['study']['pub_ids']:
-                        ref_id = r.replace(' ','')
-                        if len(ref_id) > 0:
-                            reference = Reference(
-                                ref_id,
-                                investigations=[investigation.akc_id])
-                            container.references[reference.source_uri] = reference
-                            investigation.documents.append(reference.source_uri)
-                else:
-                    ref_id = rep['study']['pub_ids'].replace(' ','')
-                    #print(ref_id.split(' '))
-                    if len(ref_id) > 0:
-                        reference = Reference(
-                            ref_id,
-                            investigations=[investigation.akc_id])
-                        container.references[reference.source_uri] = reference
-                        investigation.documents.append(reference.source_uri)
-
-            container.investigations[investigation.akc_id] = investigation
-            #print(investigation)
-            #print(container)
-            first = False
-
-        # create participant from subject data
-        participant = subjects.get(rep['subject']['subject_id'])
-        if participant is None:
-            sub = rep['subject']
-            participant = Participant(
-                akc_id(),
-                name=sub['subject_id'],
-                species=adc_ontology(sub.get('species')),
-                sex=sub.get('sex'),
-                age=sub.get('age_min'),
-                #age_max=sub['age_max'],
-                age_event=sub.get('age_event'),
-                age_unit = adc_ontology(sub.get('age_unit')),
-                race=sub.get('race'),
-                ethnicity=sub.get('ethnicity'),
-                geolocation=None
-            )
-            subjects[rep['subject']['subject_id']] = participant
-            container.participants[participant.akc_id] = participant
-            investigation.participants.append(participant.akc_id)
-
-            # transform study_group_description to StudyArm
-            # transform disease diagnosis to an immune exposure/life event
-            arm = None
-            if sub.get('diagnosis') is not None:
-                for diag in sub['diagnosis']:
-                    if diag.get('study_group_description') is not None:
-                        if arms.get(diag['study_group_description']) is None:
-                            arm = StudyArm(
-                                akc_id(),
-                                name=diag['study_group_description'],
-                                investigation=investigation.akc_id
-                            )
-                            arms[diag['study_group_description']] = arm
-                            container.study_arms[arm.akc_id] = arm
-                        else:
-                            arm = arms[diag['study_group_description']]
-                        participant.study_arm = arm.akc_id
-                    if diag.get('disease_diagnosis') is not None:
-                        le = LifeEvent(
-                            akc_id(),
-                            participant=participant.akc_id,
-                            life_event_type='immune exposure'
-                        )
-                        container.life_events[le.akc_id] = le
-                        ie = ImmuneExposure(
-                            akc_id(),
-                            t0_event=le.akc_id,
-                            disease = adc_ontology(diag.get('disease_diagnosis')),
-                            disease_stage = diag.get('disease_stage')
-                        )
-                        container.immune_exposures[ie.akc_id] = ie
-        # specimen processing
-        for s in rep['sample']:
-            specimen = samples.get(s['sample_id'])
-            if specimen is None:
-                life_event = LifeEvent(
-                    akc_id(),
-                    participant=participant.akc_id,
-                    life_event_type='specimen collection',
-                    geolocation=None,
-                    t0_event=None,
-                    start=None,
-                    duration=None,
-                    time_unit=None
-                )
-                container.life_events[life_event.akc_id] = life_event
-                specimen = Specimen(
-                    akc_id(),
-                    name=s['sample_id'],
-                    life_event=life_event.akc_id,
-                    tissue = adc_ontology(s.get('tissue'))
-                )
-                samples[s['sample_id']] = specimen
-                container.specimens[specimen.akc_id] = specimen
-
-            cell_proc = CellIsolationProcessing(
-                akc_id(),
-                specimen = specimen.akc_id,
-                tissue_processing = s.get('tissue_processing'),
-                cell_subset = adc_ontology(s.get('cell_subset')),
-                cell_phenotype = s.get('cell_phenotype'),
-                cell_species = adc_ontology(s.get('cell_species')),
-                single_cell = s.get('single_cell'),
-                cell_number = s.get('cell_number'),
-                cells_per_reaction = s.get('cells_per_reaction'),
-                cell_storage = s.get('cell_storage'),
-                cell_quality = s.get('cell_quality'),
-                cell_isolation = s.get('cell_isolation'),
-                cell_processing_protocol = s.get('cell_processing_protocol')
-            )
-            container.specimen_processings[cell_proc.akc_id] = cell_proc
-            
-            lib_proc = LibraryPreparationProcessing(
-                akc_id(),
-                specimen = specimen.akc_id,
-                template_class = s.get('template_class'),
-                template_quality = s.get('template_quality'),
-                template_amount = s.get('template_amount'),
-                template_amount_unit = adc_ontology(s.get('template_amount_unit')),
-                library_generation_method = s.get('library_generation_method'),
-                library_generation_protocol = s.get('library_generation_protocol'),
-                library_generation_kit_version = s.get('library_generation_kit_version'),
-                complete_sequences = s.get('complete_sequences').strip(),
-                physical_linkage = s.get('physical_linkage')
-            )
-            for t in s.get('pcr_target'):
-                lib_proc.pcr_target.append(t.get('pcr_target_locus'))
-            container.specimen_processings[lib_proc.akc_id] = lib_proc
-
-            f = s['sequencing_files']
-            seq_files = AIRRSequencingData(
-                akc_id(),
-                sequencing_data_id = f.get('sequencing_data_id'),
-                file_type = f.get('file_type'),
-                filename = f.get('filename'),
-                read_direction = f.get('read_direction'),
-                read_length = f.get('read_length'),
-                paired_filename = f.get('paired_filename'),
-                paired_read_direction = f.get('paired_read_direction'),
-                paired_read_length = f.get('paired_read_length')
-            )
-            container.sequence_data[seq_files.akc_id] = seq_files
-
-            sequencing_run_date = None
-            if s.get('sequencing_run_date') is not None:
-                sequencing_run_date = parse(s.get('sequencing_run_date'))
-
-            assay = AIRRSequencingAssay(
-                akc_id(),
-                repertoire_id = rep['repertoire_id'],
-                specimen = specimen.akc_id,
-                specimen_processing = [ cell_proc.akc_id, lib_proc.akc_id ],
-                sequencing_run_id = s.get('sequencing_run_id'),
-                sequencing_run_date = sequencing_run_date,
-                sequencing_platform = s.get('sequencing_platform'),
-                sequencing_kit = s.get('sequencing_kit'),
-                sequencing_facility = s.get('sequencing_facility'),
-                total_reads_passing_qc_filter = s.get('total_reads_passing_qc_filter'),
-                sequencing_files = seq_files.akc_id
-            )
-            container.assays[assay.akc_id] = assay
-
-        # data processing, not implemented
-        
+    
+    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/repertoires.airr.json', AIRRKnowledgeCommons())
+    
     # output data for just this study
     directory_name = f'{adc_data_dir}/adc_jsonl/{study}'
     try:
@@ -247,15 +42,12 @@ def repertoire_transform(cache_id):
     except FileExistsError:
         pass
 
-    #print(container)
-    #yaml_dumper.dump(container, yaml_path)
-
     # Write outputs
     container_fields = [x.name for x in dataclasses.fields(container)]
 
     # Write to JSONL and CSV
     for container_field in container_fields:
-        if container_field in [ 'chains', 'ab_tcell_receptors', 'gd_tcell_receptors', 'bcell_receptors' ]:
+        if container_field in ['chains', 'ab_tcell_receptors', 'gd_tcell_receptors', 'bcell_receptors']:
             continue
         container_slot = ak_schema_view.get_slot(container_field)
         tname = container_slot.range

--- a/ak_schema_utils.py
+++ b/ak_schema_utils.py
@@ -603,12 +603,20 @@ def load_adc_container(container):
 def write_jsonl(container, container_field, outfile, exclude=None):
     print(outfile)
     with open(outfile, 'w') as f:
-        for key in container[container_field]:
-            s = json.loads(json_dumper.dumps(container[container_field][key]))
-            doc = {}
-            doc[container_field] = s
-            f.write(json.dumps(doc))
-            f.write('\n')
+        if type(container[container_field]) == list:
+            for obj in container[container_field]:
+                s = json.loads(json_dumper.dumps(obj))
+                doc = {}
+                doc[container_field] = s
+                f.write(json.dumps(doc))
+                f.write('\n')
+        else:
+            for key in container[container_field]:
+                s = json.loads(json_dumper.dumps(container[container_field][key]))
+                doc = {}
+                doc[container_field] = s
+                f.write(json.dumps(doc))
+                f.write('\n')
 
 def write_csv(container, container_field, outfile):
     if type(container[container_field]) == list:

--- a/ak_schema_utils.py
+++ b/ak_schema_utils.py
@@ -19,7 +19,8 @@ from linkml_runtime.dumpers import yaml_dumper, json_dumper, tsv_dumper
 from ak_schema import *
 
 # data import/export directories
-ak_data_dir = '/ak_data'
+# set ak_data_dir from the environment variable AK_DATA_DIR if it exists
+ak_data_dir = os.environ.get('AK_DATA_DIR', '/ak_data')
 adc_data_dir = ak_data_dir + '/vdjserver-adc-cache'
 adc_cache_dir = adc_data_dir + '/cache'
 iedb_data_dir = ak_data_dir + '/iedb'

--- a/ak_schema_utils.py
+++ b/ak_schema_utils.py
@@ -611,7 +611,10 @@ def write_jsonl(container, container_field, outfile, exclude=None):
             f.write('\n')
 
 def write_csv(container, container_field, outfile):
-    rows = list(container[container_field].values())
+    if type(container[container_field]) == list:
+        rows = container[container_field]
+    else:
+        rows = list(container[container_field].values())
     if len(rows) < 1:
         print(f"Skipping empty data for {container_field}")
         return

--- a/ak_schema_utils.py
+++ b/ak_schema_utils.py
@@ -21,9 +21,12 @@ from ak_schema import *
 # data import/export directories
 # set ak_data_dir from the environment variable AK_DATA_DIR if it exists
 ak_data_dir = os.environ.get('AK_DATA_DIR', '/ak_data')
+
 adc_data_dir = ak_data_dir + '/vdjserver-adc-cache'
 adc_cache_dir = adc_data_dir + '/cache'
 iedb_data_dir = ak_data_dir + '/iedb'
+vdjbase_data_dir = ak_data_dir + '/vdjbase'
+
 ak_load_dir = ak_data_dir + '/ak-data-load'
 
 ak_schema_view = SchemaView("ak-schema/project/linkml/ak_schema.yaml")
@@ -197,7 +200,7 @@ cache_list.extend(vdjserver_ig_cache_list)
 cache_list.extend(vdjserver_both_cache_list)
 
 cache_list.extend(other_cache_list)
-cache_list.extend(vdjbase_cache_list)
+#cache_list.extend(vdjbase_cache_list)
 
 #cache_list.extend(test_cache_list)
 

--- a/ak_schema_utils.py
+++ b/ak_schema_utils.py
@@ -183,6 +183,10 @@ test_cache_list = [
     '6508961642208563691-242ac113-0001-012', # PRJNA300878
 ]
 
+vdjbase_cache_list = [
+    'vdjbase-2025-08-231-0001-012',
+]
+
 cache_list = []
 cache_list.extend(ipa_tcr_cache_list)
 cache_list.extend(ipa_ig_cache_list)
@@ -193,6 +197,7 @@ cache_list.extend(vdjserver_ig_cache_list)
 cache_list.extend(vdjserver_both_cache_list)
 
 cache_list.extend(other_cache_list)
+cache_list.extend(vdjbase_cache_list)
 
 #cache_list.extend(test_cache_list)
 

--- a/download_vdjbase_data.sh
+++ b/download_vdjbase_data.sh
@@ -1,4 +1,5 @@
-cd akc-data/vdjserver-adc-cache/cache/vdjbase-2025-08-231-0001-012
+mkdir -p /ak_data/vdjbase/vdjbase-2025-08-231-0001-012
+cd /ak_data/vdjbase/vdjbase-2025-08-231-0001-012
 curl "https://vdjbase.org/api/v1/genomic/all_samples_metadata/Homo%20sapiens/IGH" >genomic_metadata_IGH.json
 curl "https://vdjbase.org/api/v1/genomic/all_samples_metadata/Homo%20sapiens/IGK" >genomic_metadata_IGK.json
 curl "https://vdjbase.org/api/v1/genomic/all_samples_metadata/Homo%20sapiens/IGL" >genomic_metadata_IGL.json

--- a/download_vdjbase_data.sh
+++ b/download_vdjbase_data.sh
@@ -1,0 +1,10 @@
+cd akc-data/vdjserver-adc-cache/cache/vdjbase-2025-08-231-0001-012
+curl "https://vdjbase.org/api/v1/genomic/all_samples_metadata/Homo%20sapiens/IGH" >genomic_metadata_IGH.json
+curl "https://vdjbase.org/api/v1/genomic/all_samples_metadata/Homo%20sapiens/IGK" >genomic_metadata_IGK.json
+curl "https://vdjbase.org/api/v1/genomic/all_samples_metadata/Homo%20sapiens/IGL" >genomic_metadata_IGL.json
+curl "https://vdjbase.org/api/v1/airrseq/all_samples_metadata/Homo%20sapiens/IGH" >airrseq_metadata_IGH.json
+curl "https://vdjbase.org/api/v1/airrseq/all_samples_metadata/Homo%20sapiens/IGK" >airrseq_metadata_IGK.json
+curl "https://vdjbase.org/api/v1/airrseq/all_samples_metadata/Homo%20sapiens/IGL" >airrseq_metadata_IGL.json
+curl "https://vdjbase.org/api/v1/airrseq/all_samples_metadata/Homo%20sapiens/TRB" >airrseq_metadata_TRB.json
+curl "https://vdjbase.org/api/v1/airrseq/all_subjects_genotype/Homo%20sapiens" >airrseq_all_genotypes.json
+curl "https://vdjbase.org/api/v1/genomic/all_subjects_genotype/Homo%20sapiens" >genomic_all_genotypes.json

--- a/download_vdjbase_data.sh
+++ b/download_vdjbase_data.sh
@@ -9,3 +9,5 @@ curl "https://vdjbase.org/api/v1/airrseq/all_samples_metadata/Homo%20sapiens/IGL
 curl "https://vdjbase.org/api/v1/airrseq/all_samples_metadata/Homo%20sapiens/TRB" >airrseq_metadata_TRB.json
 curl "https://vdjbase.org/api/v1/airrseq/all_subjects_genotype/Homo%20sapiens" >airrseq_all_genotypes.json
 curl "https://vdjbase.org/api/v1/genomic/all_subjects_genotype/Homo%20sapiens" >genomic_all_genotypes.json
+# fix extraneous Unicode in PMID entries (this will be corrected in VDJbase soon)
+sed -i 's/PMID:\\u00d6\\u00b2\\u00c2\\u00a032377375/PMID:32377375/g' *.json

--- a/transform_airr_genotypes.py
+++ b/transform_airr_genotypes.py
@@ -1,0 +1,67 @@
+import airr
+import copy
+from dateutil.parser import parse
+
+from ak_schema import (
+    Investigation,
+    Participant,
+    StudyArm,
+    LifeEvent,
+    ImmuneExposure,
+    Specimen,
+    CellIsolationProcessing,
+    LibraryPreparationProcessing,
+    AIRRSequencingData,
+    AIRRSequencingAssay,
+    Reference,
+    Genotype,
+    GenotypeSet,
+)
+from ak_schema_utils import (
+    akc_id,
+    adc_ontology,
+    to_datetime,
+)
+
+
+def transform_airr_genotypes(genotype_filename, container):
+    """Transform ADC repertoire metadata to AK objects.
+    
+    Args:
+        genotype_filename (str): The path to the genotype JSON file
+        container (AIRRKnowledgeCommons): The container to populate
+    Returns:
+        AIRRKnowledgeCommons: Container with transformed data
+    """
+    print('Processing  genotype file:', genotype_filename)
+
+    # Load the AIRR data
+    data = airr.read_airr(genotype_filename)
+
+    genotype_sets = []
+    for row in data['genotype_class_list']:
+        subject = row['subject_name']
+        genotype_set = row['genotypeSet']
+        receptor_genotype_set_id = genotype_set['receptor_genotype_set_id']
+        class_list = genotype_set['genotype_class_list']
+
+        genotypes = []
+        for genotype in class_list:
+            genotypes.append(Genotype(
+                receptor_genotype_id=genotype['receptor_genotype_id'],
+                locus=genotype['locus'],
+                documented_alleles=copy.deepcopy(genotype.get('documented_alleles', list())),
+                undocumented_alleles=copy.deepcopy(genotype.get('undocumented_alleles', list())),
+                deleted_genes=copy.deepcopy(genotype.get('deleted_genes', list())),
+                inference_process=genotype.get('inference_process', None)
+            ))
+        
+        genotype_sets.append(GenotypeSet(
+            akc_id(),
+            receptor_genotype_set_id=receptor_genotype_set_id,
+            genotype_class_list=genotypes
+        ))
+
+
+    return container    
+

--- a/transform_airr_genotypes.py
+++ b/transform_airr_genotypes.py
@@ -108,6 +108,7 @@ def transform_airr_genotypes(genotype_filename, vdjbase_name_to_akc_ids, contain
             akc_id(),
             data_transformation_types=['genotype_inference'],
         )
+        container['transformations'][data_transformation.akc_id] = data_transformation
 
         for recs in participant_id_to_sequencing_files[participant_id]:
             sequencing_file_id = recs['sequencing_files_id']
@@ -115,10 +116,11 @@ def transform_airr_genotypes(genotype_filename, vdjbase_name_to_akc_ids, contain
             # at the moment the map is not stored in the container
             # at the moment I create a separate map for each sequencing file, but perhaps the map should link to a list of sequencing files?
             io_map = InputOutputDataMap(
-                data_transformation=data_transformation,
+                data_transformation=data_transformation.akc_id,
                 has_specified_input=sequencing_file_id,
                 has_specified_output=genotype_data.akc_id,
             )
+            container['input_output_map'].append(io_map)
 
     return container    
 

--- a/transform_airr_genotypes.py
+++ b/transform_airr_genotypes.py
@@ -23,6 +23,10 @@ from ak_schema_utils import (
     to_datetime,
 )
 
+# notes from schema meeting:
+# - make a GenomicGenotyping assay, maybe in ak_specimens.yaml ? don't really understand the structure of the files
+# - add GenotypeSet as a data item for AIRRSequencingData or GenomicGenontypingAssay
+# assay ontology: https://www.ebi.ac.uk/ols4/ontologies/obi/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FOBI_0000435?lang=en
 
 def transform_airr_genotypes(genotype_filename, container):
     """Transform ADC repertoire metadata to AK objects.
@@ -57,7 +61,6 @@ def transform_airr_genotypes(genotype_filename, container):
             ))
         
         genotype_sets.append(GenotypeSet(
-            akc_id(),
             receptor_genotype_set_id=receptor_genotype_set_id,
             genotype_class_list=genotypes
         ))

--- a/transform_airr_genotypes.py
+++ b/transform_airr_genotypes.py
@@ -95,15 +95,7 @@ def transform_airr_genotypes(genotype_filename, vdjbase_name_to_akc_ids, contain
         )
 
         container['datasets'][genotype_data.akc_id] = genotype_data
-       
-        '''
-        This throws an error:
-        Exception has occurred: ValueError
-            DataTransformation({
-            'akc_id': 'AKC:337ce816-a54c-432f-8208-47d63388e5ca',
-            'data_transformation_types': [DataTransformationTypeEnum(text='genotype_inference')]
-            }) is not a valid URI or CURIE
-        '''
+
         data_transformation = DataTransformation(
             akc_id(),
             data_transformation_types=['genotype_inference'],
@@ -113,8 +105,6 @@ def transform_airr_genotypes(genotype_filename, vdjbase_name_to_akc_ids, contain
         for recs in participant_id_to_sequencing_files[participant_id]:
             sequencing_file_id = recs['sequencing_files_id']
 
-            # at the moment the map is not stored in the container
-            # at the moment I create a separate map for each sequencing file, but perhaps the map should link to a list of sequencing files?
             io_map = InputOutputDataMap(
                 data_transformation=data_transformation.akc_id,
                 has_specified_input=sequencing_file_id,

--- a/transform_airr_repertoires.py
+++ b/transform_airr_repertoires.py
@@ -36,7 +36,7 @@ def transform_airr_repertoires(repertoire_filename, container):
     data = airr.read_airr(repertoire_filename)
 
     # loop through the repertoires
-    first = True
+    investigations = {}
     subjects = {}
     arms = {}
     samples = {}
@@ -47,8 +47,9 @@ def transform_airr_repertoires(repertoire_filename, container):
         if progress_count % 75 == 0:
             print()
 
-        # create investigation object
-        if first:
+        study_id = rep['study'].get('study_id')
+
+        if study_id not in investigations:
             if 'ImmuneCODE' in rep['study'].get('study_id'):
                 archival_id = rep['study'].get('study_id').replace(' ', '')
             else:
@@ -89,7 +90,11 @@ def transform_airr_repertoires(repertoire_filename, container):
             container.investigations[investigation.akc_id] = investigation
             # print(investigation)
             # print(container)
-            first = False
+
+            print('Processing study:', study_id, investigation.name)
+            investigations[study_id] = investigation
+        else:
+            investigation = investigations[study_id]
 
         # create participant from subject data
         participant = subjects.get(rep['subject']['subject_id'])

--- a/transform_airr_repertoires.py
+++ b/transform_airr_repertoires.py
@@ -20,6 +20,7 @@ from ak_schema_utils import (
     to_datetime,
 )
 
+
 def transform_airr_repertoires(repertoire_filename, container):
     """Transform ADC repertoire metadata to AK objects.
        
@@ -51,7 +52,7 @@ def transform_airr_repertoires(repertoire_filename, container):
 
     # loop through the repertoires in the file
     for rep in data['Repertoire']:
-        #if 'P27_I25' in rep['repertoire_id']:
+        #if 'P25_I1_' in rep['repertoire_id']:
         #    breakpoint()
         progress_count += 1
         print('.', end='', flush=True)
@@ -63,7 +64,6 @@ def transform_airr_repertoires(repertoire_filename, container):
         if not study_id:
             continue    # Don't process repertoires that have not been deposited in an archive
 
-        
         # Fixes for specific issues encountered in current data
         if 'ImmuneCODE' in rep['study'].get('study_id'):
             archival_id = rep['study'].get('study_id').replace(' ', '')
@@ -134,7 +134,7 @@ def transform_airr_repertoires(repertoire_filename, container):
                     sample_ids[sp.name] = sp.akc_id
 
             current_investigation = investigation_id
-  
+
         # create participant from subject data
         participant_id = subject_ids.get(rep['subject']['subject_id'])
         if participant_id:
@@ -193,7 +193,6 @@ def transform_airr_repertoires(repertoire_filename, container):
                         )
                         container.immune_exposures[ie.akc_id] = ie
 
-
         # specimen processing
         for s in rep['sample']:
             sample_id = s.get('sample_id', rep['subject']['subject_id'])
@@ -225,74 +224,74 @@ def transform_airr_repertoires(repertoire_filename, container):
                 sample_ids[sample_id] = specimen.akc_id
                 container.specimens[specimen.akc_id] = specimen
 
-            cell_proc = CellIsolationProcessing(
-                akc_id(),
-                specimen=specimen.akc_id,
-                tissue_processing=s.get('tissue_processing'),
-                cell_subset=adc_ontology(s.get('cell_subset')),
-                cell_phenotype=s.get('cell_phenotype'),
-                cell_species=adc_ontology(s.get('cell_species')),
-                single_cell=s.get('single_cell'),
-                cell_number=s.get('cell_number'),
-                cells_per_reaction=s.get('cells_per_reaction'),
-                cell_storage=s.get('cell_storage'),
-                cell_quality=s.get('cell_quality'),
-                cell_isolation=s.get('cell_isolation'),
-                cell_processing_protocol=s.get('cell_processing_protocol')
-            )
-            container.specimen_processings[cell_proc.akc_id] = cell_proc
+                cell_proc = CellIsolationProcessing(
+                    akc_id(),
+                    specimen=specimen.akc_id,
+                    tissue_processing=s.get('tissue_processing'),
+                    cell_subset=adc_ontology(s.get('cell_subset')),
+                    cell_phenotype=s.get('cell_phenotype'),
+                    cell_species=adc_ontology(s.get('cell_species')),
+                    single_cell=s.get('single_cell'),
+                    cell_number=s.get('cell_number'),
+                    cells_per_reaction=s.get('cells_per_reaction'),
+                    cell_storage=s.get('cell_storage'),
+                    cell_quality=s.get('cell_quality'),
+                    cell_isolation=s.get('cell_isolation'),
+                    cell_processing_protocol=s.get('cell_processing_protocol')
+                )
+                container.specimen_processings[cell_proc.akc_id] = cell_proc
 
-            lib_proc = LibraryPreparationProcessing(
-                akc_id(),
-                specimen=specimen.akc_id,
-                template_class=s.get('template_class'),
-                template_quality=s.get('template_quality'),
-                template_amount=s.get('template_amount'),
-                template_amount_unit=adc_ontology(s.get('template_amount_unit')),
-                library_generation_method=s.get('library_generation_method'),
-                library_generation_protocol=s.get('library_generation_protocol'),
-                library_generation_kit_version=s.get('library_generation_kit_version'),
-                complete_sequences=s.get('complete_sequences').strip(),
-                physical_linkage=s.get('physical_linkage')
-            )
-            for t in s.get('pcr_target'):
-                lib_proc.pcr_target.append(t.get('pcr_target_locus'))
-            container.specimen_processings[lib_proc.akc_id] = lib_proc
+                lib_proc = LibraryPreparationProcessing(
+                    akc_id(),
+                    specimen=specimen.akc_id,
+                    template_class=s.get('template_class'),
+                    template_quality=s.get('template_quality'),
+                    template_amount=s.get('template_amount'),
+                    template_amount_unit=adc_ontology(s.get('template_amount_unit')),
+                    library_generation_method=s.get('library_generation_method'),
+                    library_generation_protocol=s.get('library_generation_protocol'),
+                    library_generation_kit_version=s.get('library_generation_kit_version'),
+                    complete_sequences=s.get('complete_sequences').strip(),
+                    physical_linkage=s.get('physical_linkage')
+                )
+                for t in s.get('pcr_target'):
+                    lib_proc.pcr_target.append(t.get('pcr_target_locus'))
+                container.specimen_processings[lib_proc.akc_id] = lib_proc
 
-            f = s['sequencing_files']
-            seq_files = AIRRSequencingData(
-                akc_id(),
-                sequencing_data_id=f.get('sequencing_data_id'),
-                file_type=f.get('file_type'),
-                filename=f.get('filename'),
-                read_direction=f.get('read_direction'),
-                read_length=f.get('read_length'),
-                paired_filename=f.get('paired_filename'),
-                paired_read_direction=f.get('paired_read_direction'),
-                paired_read_length=f.get('paired_read_length')
-            )
-            container.sequence_data[seq_files.akc_id] = seq_files
+                f = s['sequencing_files']
+                seq_files = AIRRSequencingData(
+                    akc_id(),
+                    sequencing_data_id=f.get('sequencing_data_id'),
+                    file_type=f.get('file_type'),
+                    filename=f.get('filename'),
+                    read_direction=f.get('read_direction'),
+                    read_length=f.get('read_length'),
+                    paired_filename=f.get('paired_filename'),
+                    paired_read_direction=f.get('paired_read_direction'),
+                    paired_read_length=f.get('paired_read_length')
+                )
+                container.sequence_data[seq_files.akc_id] = seq_files
 
-            sequencing_run_date = None
-            if s.get('sequencing_run_date') is not None:
-                sequencing_run_date = parse(s.get('sequencing_run_date'))
+                sequencing_run_date = None
+                if s.get('sequencing_run_date') is not None:
+                    sequencing_run_date = parse(s.get('sequencing_run_date'))
 
-            assay = AIRRSequencingAssay(
-                akc_id(),
-                repertoire_id=rep['repertoire_id'],
-                specimen=specimen.akc_id,
-                specimen_processing=[cell_proc.akc_id, lib_proc.akc_id],
-                sequencing_run_id=s.get('sequencing_run_id'),
-                sequencing_run_date=sequencing_run_date,
-                sequencing_platform=s.get('sequencing_platform'),
-                sequencing_kit=s.get('sequencing_kit'),
-                sequencing_facility=s.get('sequencing_facility'),
-                total_reads_passing_qc_filter=s.get('total_reads_passing_qc_filter'),
-                sequencing_files=seq_files.akc_id
-            )
-            container.assays[assay.akc_id] = assay
+                assay = AIRRSequencingAssay(
+                    akc_id(),
+                    repertoire_id=rep['repertoire_id'],
+                    specimen=specimen.akc_id,
+                    specimen_processing=[cell_proc.akc_id, lib_proc.akc_id],
+                    sequencing_run_id=s.get('sequencing_run_id'),
+                    sequencing_run_date=sequencing_run_date,
+                    sequencing_platform=s.get('sequencing_platform'),
+                    sequencing_kit=s.get('sequencing_kit'),
+                    sequencing_facility=s.get('sequencing_facility'),
+                    total_reads_passing_qc_filter=s.get('total_reads_passing_qc_filter'),
+                    sequencing_files=seq_files.akc_id
+                )
+                container.assays[assay.akc_id] = assay
 
-        # data processing, not implemented
+            # data processing, not implemented
 
     # Print final newline if we didn't just print one
     if progress_count % 75 != 0:

--- a/transform_airr_repertoires.py
+++ b/transform_airr_repertoires.py
@@ -1,0 +1,243 @@
+import airr
+from dateutil.parser import parse
+
+from ak_schema import (
+    Investigation,
+    Participant,
+    StudyArm,
+    LifeEvent,
+    ImmuneExposure,
+    Specimen,
+    CellIsolationProcessing,
+    LibraryPreparationProcessing,
+    AIRRSequencingData,
+    AIRRSequencingAssay,
+    Reference
+)
+from ak_schema_utils import (
+    akc_id,
+    adc_ontology,
+    to_datetime,
+)
+
+
+def transform_airr_repertoires(repertoire_filename, container):
+    """Transform ADC repertoire metadata to AK objects.
+    
+    Args:
+        repertoire_filename (str): The path to the repertoire JSON file
+        container (AIRRKnowledgeCommons): The container to populate
+    Returns:
+        AIRRKnowledgeCommons: Container with transformed data
+    """
+    print('Processing  repertoire file:', repertoire_filename)
+
+    # Load the AIRR data
+    data = airr.read_airr(repertoire_filename)
+
+    # loop through the repertoires
+    first = True
+    subjects = {}
+    arms = {}
+    samples = {}
+    progress_count = 0
+    for rep in data['Repertoire']:
+        progress_count += 1
+        print('.', end='', flush=True)
+        if progress_count % 75 == 0:
+            print()
+
+        # create investigation object
+        if first:
+            if 'ImmuneCODE' in rep['study'].get('study_id'):
+                archival_id = rep['study'].get('study_id').replace(' ', '')
+            else:
+                archival_id = rep['study'].get('study_id')
+
+            investigation = Investigation(
+                akc_id(),
+                name=rep['study'].get('study_title'),
+                description=rep['study'].get('study_description'),
+                archival_id=archival_id,
+                investigation_type=adc_ontology(rep['study']['study_type']),
+                inclusion_exclusion_criteria=rep['study'].get('inclusion_exclusion_criteria'),
+                release_date=to_datetime(rep['study'].get('adc_release_date')),
+                update_date=to_datetime(rep['study'].get('adc_update_date'))
+            )
+
+            # documents
+            if rep['study'].get('pub_ids') is not None:
+                if isinstance(rep['study']['pub_ids'], list):
+                    for r in rep['study']['pub_ids']:
+                        ref_id = r.replace(' ', '')
+                        if len(ref_id) > 0:
+                            reference = Reference(
+                                ref_id,
+                                investigations=[investigation.akc_id])
+                            container.references[reference.source_uri] = reference
+                            investigation.documents.append(reference.source_uri)
+                else:
+                    ref_id = rep['study']['pub_ids'].replace(' ', '')
+                    # print(ref_id.split(' '))
+                    if len(ref_id) > 0:
+                        reference = Reference(
+                            ref_id,
+                            investigations=[investigation.akc_id])
+                        container.references[reference.source_uri] = reference
+                        investigation.documents.append(reference.source_uri)
+
+            container.investigations[investigation.akc_id] = investigation
+            # print(investigation)
+            # print(container)
+            first = False
+
+        # create participant from subject data
+        participant = subjects.get(rep['subject']['subject_id'])
+        if participant is None:
+            sub = rep['subject']
+            participant = Participant(
+                akc_id(),
+                name=sub['subject_id'],
+                species=adc_ontology(sub.get('species')),
+                sex=sub.get('sex'),
+                age=sub.get('age_min'),
+                # age_max=sub['age_max'],
+                age_event=sub.get('age_event'),
+                age_unit=adc_ontology(sub.get('age_unit')),
+                race=sub.get('race'),
+                ethnicity=sub.get('ethnicity'),
+                geolocation=None
+            )
+            subjects[rep['subject']['subject_id']] = participant
+            container.participants[participant.akc_id] = participant
+            investigation.participants.append(participant.akc_id)
+
+            # transform study_group_description to StudyArm
+            # transform disease diagnosis to an immune exposure/life event
+            arm = None
+            if sub.get('diagnosis') is not None:
+                for diag in sub['diagnosis']:
+                    if diag.get('study_group_description') is not None:
+                        if arms.get(diag['study_group_description']) is None:
+                            arm = StudyArm(
+                                akc_id(),
+                                name=diag['study_group_description'],
+                                investigation=investigation.akc_id
+                            )
+                            arms[diag['study_group_description']] = arm
+                            container.study_arms[arm.akc_id] = arm
+                        else:
+                            arm = arms[diag['study_group_description']]
+                        participant.study_arm = arm.akc_id
+                    if diag.get('disease_diagnosis') is not None:
+                        le = LifeEvent(
+                            akc_id(),
+                            participant=participant.akc_id,
+                            life_event_type='immune exposure'
+                        )
+                        container.life_events[le.akc_id] = le
+                        ie = ImmuneExposure(
+                            akc_id(),
+                            t0_event=le.akc_id,
+                            disease=adc_ontology(diag.get('disease_diagnosis')),
+                            disease_stage=diag.get('disease_stage')
+                        )
+                        container.immune_exposures[ie.akc_id] = ie
+        # specimen processing
+        for s in rep['sample']:
+            specimen = samples.get(s['sample_id'])
+            if specimen is None:
+                life_event = LifeEvent(
+                    akc_id(),
+                    participant=participant.akc_id,
+                    life_event_type='specimen collection',
+                    geolocation=None,
+                    t0_event=None,
+                    start=None,
+                    duration=None,
+                    time_unit=None
+                )
+                container.life_events[life_event.akc_id] = life_event
+                specimen = Specimen(
+                    akc_id(),
+                    name=s['sample_id'],
+                    life_event=life_event.akc_id,
+                    tissue=adc_ontology(s.get('tissue'))
+                )
+                samples[s['sample_id']] = specimen
+                container.specimens[specimen.akc_id] = specimen
+
+            cell_proc = CellIsolationProcessing(
+                akc_id(),
+                specimen=specimen.akc_id,
+                tissue_processing=s.get('tissue_processing'),
+                cell_subset=adc_ontology(s.get('cell_subset')),
+                cell_phenotype=s.get('cell_phenotype'),
+                cell_species=adc_ontology(s.get('cell_species')),
+                single_cell=s.get('single_cell'),
+                cell_number=s.get('cell_number'),
+                cells_per_reaction=s.get('cells_per_reaction'),
+                cell_storage=s.get('cell_storage'),
+                cell_quality=s.get('cell_quality'),
+                cell_isolation=s.get('cell_isolation'),
+                cell_processing_protocol=s.get('cell_processing_protocol')
+            )
+            container.specimen_processings[cell_proc.akc_id] = cell_proc
+
+            lib_proc = LibraryPreparationProcessing(
+                akc_id(),
+                specimen=specimen.akc_id,
+                template_class=s.get('template_class'),
+                template_quality=s.get('template_quality'),
+                template_amount=s.get('template_amount'),
+                template_amount_unit=adc_ontology(s.get('template_amount_unit')),
+                library_generation_method=s.get('library_generation_method'),
+                library_generation_protocol=s.get('library_generation_protocol'),
+                library_generation_kit_version=s.get('library_generation_kit_version'),
+                complete_sequences=s.get('complete_sequences').strip(),
+                physical_linkage=s.get('physical_linkage')
+            )
+            for t in s.get('pcr_target'):
+                lib_proc.pcr_target.append(t.get('pcr_target_locus'))
+            container.specimen_processings[lib_proc.akc_id] = lib_proc
+
+            f = s['sequencing_files']
+            seq_files = AIRRSequencingData(
+                akc_id(),
+                sequencing_data_id=f.get('sequencing_data_id'),
+                file_type=f.get('file_type'),
+                filename=f.get('filename'),
+                read_direction=f.get('read_direction'),
+                read_length=f.get('read_length'),
+                paired_filename=f.get('paired_filename'),
+                paired_read_direction=f.get('paired_read_direction'),
+                paired_read_length=f.get('paired_read_length')
+            )
+            container.sequence_data[seq_files.akc_id] = seq_files
+
+            sequencing_run_date = None
+            if s.get('sequencing_run_date') is not None:
+                sequencing_run_date = parse(s.get('sequencing_run_date'))
+
+            assay = AIRRSequencingAssay(
+                akc_id(),
+                repertoire_id=rep['repertoire_id'],
+                specimen=specimen.akc_id,
+                specimen_processing=[cell_proc.akc_id, lib_proc.akc_id],
+                sequencing_run_id=s.get('sequencing_run_id'),
+                sequencing_run_date=sequencing_run_date,
+                sequencing_platform=s.get('sequencing_platform'),
+                sequencing_kit=s.get('sequencing_kit'),
+                sequencing_facility=s.get('sequencing_facility'),
+                total_reads_passing_qc_filter=s.get('total_reads_passing_qc_filter'),
+                sequencing_files=seq_files.akc_id
+            )
+            container.assays[assay.akc_id] = assay
+
+        # data processing, not implemented
+
+    # Print final newline if we didn't just print one
+    if progress_count % 75 != 0:
+        print()
+
+    return container

--- a/transform_airr_repertoires.py
+++ b/transform_airr_repertoires.py
@@ -167,7 +167,6 @@ def transform_airr_repertoires(repertoire_filename, container):
                         arm_id = arm_ids.get(diag['study_group_description'])
                         if arm_id:
                             arm = container.study_arms[arm_id]
-                            participant.study_arm = arm.akc_id
                         else:
                             arm = StudyArm(
                                 akc_id(),
@@ -176,8 +175,9 @@ def transform_airr_repertoires(repertoire_filename, container):
                             )
                             arm_ids[diag['study_group_description']] = arm.akc_id
                             container.study_arms[arm.akc_id] = arm
-                    disease_diagnosis = diag.get('disease_diagnosis')
+                        participant.study_arm = arm.akc_id
 
+                    disease_diagnosis = diag.get('disease_diagnosis')
                     if disease_diagnosis and disease_diagnosis.get('id'):
                         le = LifeEvent(
                             akc_id(),

--- a/vdjbase_metadata_transform.py
+++ b/vdjbase_metadata_transform.py
@@ -37,6 +37,7 @@ def repertoire_transform(cache_id):
     #    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/' + filename, container)
 
     container = transform_airr_genotypes(adc_cache_dir + '/' + study + '/airrseq_all_genotypes.json', container)
+    container = transform_airr_genotypes(adc_cache_dir + '/' + study + '/genomic_all_genotypes.json', container)
     
     # output data for just this study
     directory_name = f'{adc_data_dir}/adc_jsonl/{study}'

--- a/vdjbase_metadata_transform.py
+++ b/vdjbase_metadata_transform.py
@@ -1,0 +1,70 @@
+import dataclasses
+import click
+import sys
+import os
+from linkml_runtime.utils.schemaview import SchemaView
+from ak_schema import AIRRKnowledgeCommons
+from ak_schema_utils import (
+    cache_list,
+    write_jsonl,
+    write_csv,
+    write_all_relationships,
+    adc_data_dir,
+    adc_cache_dir
+)
+from transform_airr_repertoires import transform_airr_repertoires
+from transform_airr_genotypes import transform_airr_genotypes
+
+ak_schema_view = SchemaView("ak-schema/project/linkml/ak_schema.yaml")
+
+
+@click.command()
+@click.argument('cache_id')
+def repertoire_transform(cache_id):
+    """Transform VDJbase metadata to AK objects."""
+
+    if cache_id not in cache_list:
+        print(f"Given cache id: {cache_id} is not in the study list")
+        sys.exit(1)
+
+    study = cache_id
+    container = AIRRKnowledgeCommons()
+
+    #for filename in ['genomic_metadata_IGH.json', 'genomic_metadata_IGK.json', 'genomic_metadata_IGL.json']:
+    #    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/' + filename, container)
+
+    #for filename in ['airrseq_metadata_IGH.json', 'airrseq_metadata_IGK.json', 'airrseq_metadata_IGL.json', 'airrseq_metadata_TRB.json']:
+    #    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/' + filename, container)
+
+    container = transform_airr_genotypes(adc_cache_dir + '/' + study + '/airrseq_all_genotypes.json', container)
+    
+    # output data for just this study
+    directory_name = f'{adc_data_dir}/adc_jsonl/{study}'
+    try:
+        os.mkdir(directory_name)
+    except FileExistsError:
+        pass
+    directory_name = f'{adc_data_dir}/adc_tsv/{study}'
+    try:
+        os.mkdir(directory_name)
+    except FileExistsError:
+        pass
+
+    # Write outputs
+    container_fields = [x.name for x in dataclasses.fields(container)]
+
+    # Write to JSONL and CSV
+    for container_field in container_fields:
+        if container_field in ['chains', 'ab_tcell_receptors', 'gd_tcell_receptors', 'bcell_receptors']:
+            continue
+        container_slot = ak_schema_view.get_slot(container_field)
+        tname = container_slot.range
+        write_jsonl(container, container_field, f'{adc_data_dir}/adc_jsonl/{study}/{tname}.jsonl')
+        write_csv(container, container_field, f'{adc_data_dir}/adc_tsv/{study}/{tname}.csv')
+
+    # CSV relationships
+    write_all_relationships(container, f'{adc_data_dir}/adc_tsv/{study}/')
+
+
+if __name__ == "__main__":
+    repertoire_transform()

--- a/vdjbase_metadata_transform.py
+++ b/vdjbase_metadata_transform.py
@@ -5,12 +5,11 @@ import os
 from linkml_runtime.utils.schemaview import SchemaView
 from ak_schema import AIRRKnowledgeCommons
 from ak_schema_utils import (
-    cache_list,
+    vdjbase_cache_list,
     write_jsonl,
     write_csv,
     write_all_relationships,
-    adc_data_dir,
-    adc_cache_dir
+    vdjbase_data_dir
 )
 from transform_airr_repertoires import transform_airr_repertoires
 from transform_airr_genotypes import transform_airr_genotypes
@@ -23,7 +22,7 @@ ak_schema_view = SchemaView("ak-schema/project/linkml/ak_schema.yaml")
 def repertoire_transform(cache_id):
     """Transform VDJbase metadata to AK objects."""
 
-    if cache_id not in cache_list:
+    if cache_id not in vdjbase_cache_list:
         print(f"Given cache id: {cache_id} is not in the study list")
         sys.exit(1)
 
@@ -36,16 +35,16 @@ def repertoire_transform(cache_id):
     #for filename in ['airrseq_metadata_IGH.json', 'airrseq_metadata_IGK.json', 'airrseq_metadata_IGL.json', 'airrseq_metadata_TRB.json']:
     #    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/' + filename, container)
 
-    container = transform_airr_genotypes(adc_cache_dir + '/' + study + '/airrseq_all_genotypes.json', container)
-    container = transform_airr_genotypes(adc_cache_dir + '/' + study + '/genomic_all_genotypes.json', container)
+    container = transform_airr_genotypes(vdjbase_data_dir + '/' + study + '/airrseq_all_genotypes.json', container)
+    container = transform_airr_genotypes(vdjbase_data_dir + '/' + study + '/genomic_all_genotypes.json', container)
     
     # output data for just this study
-    directory_name = f'{adc_data_dir}/adc_jsonl/{study}'
+    directory_name = f'{vdjbase_data_dir}/vdjbase_jsonl/{study}'
     try:
         os.mkdir(directory_name)
     except FileExistsError:
         pass
-    directory_name = f'{adc_data_dir}/adc_tsv/{study}'
+    directory_name = f'{vdjbase_data_dir}/vdjbase_tsv/{study}'
     try:
         os.mkdir(directory_name)
     except FileExistsError:
@@ -60,11 +59,11 @@ def repertoire_transform(cache_id):
             continue
         container_slot = ak_schema_view.get_slot(container_field)
         tname = container_slot.range
-        write_jsonl(container, container_field, f'{adc_data_dir}/adc_jsonl/{study}/{tname}.jsonl')
-        write_csv(container, container_field, f'{adc_data_dir}/adc_tsv/{study}/{tname}.csv')
+        write_jsonl(container, container_field, f'{vdjbase_data_dir}/vdjbase_jsonl/{study}/{tname}.jsonl')
+        write_csv(container, container_field, f'{vdjbase_data_dir}/vdjbase_tsv/{study}/{tname}.csv')
 
     # CSV relationships
-    write_all_relationships(container, f'{adc_data_dir}/adc_tsv/{study}/')
+    write_all_relationships(container, f'{vdjbase_data_dir}/vdjbase_tsv/{study}/')
 
 
 if __name__ == "__main__":

--- a/vdjbase_metadata_transform.py
+++ b/vdjbase_metadata_transform.py
@@ -3,18 +3,129 @@ import click
 import sys
 import os
 from linkml_runtime.utils.schemaview import SchemaView
+import airr
 from ak_schema import AIRRKnowledgeCommons
 from ak_schema_utils import (
     vdjbase_cache_list,
     write_jsonl,
     write_csv,
     write_all_relationships,
-    vdjbase_data_dir
+    vdjbase_data_dir,
 )
 from transform_airr_repertoires import transform_airr_repertoires
 from transform_airr_genotypes import transform_airr_genotypes
 
 ak_schema_view = SchemaView("ak-schema/project/linkml/ak_schema.yaml")
+
+
+def map_vdjbase_name_to_study_subject(metadata_file):
+    """Create a mapping of repertoire_id to study_subject from an AIRR metadata file.
+       This does involve reading the file again, but the overhead is pretty low and it
+       keeps this vdjbase-specific reference mapping logic out of the more general
+       transform_airr_repertoires function.
+    """
+
+    data = airr.read_airr(metadata_file)
+    vdjbase_name_to_study_subject = {}
+
+    for repertoire in data['Repertoire']:
+        repertoire_id = repertoire['repertoire_id']
+        repertoire_id = repertoire_id.split('_')
+        if len(repertoire_id) > 2 and repertoire_id[0].startswith('P') and repertoire_id[1].startswith('I'):
+            vdjbase_subject = '_'.join(repertoire_id[0:2])
+            study = repertoire['study']['study_id']
+
+            if not study:
+                continue    # Don't process repertoires that have not been deposited in an archive
+
+            if 'BioProject: ' in study:
+                study = study.replace('BioProject: ', '')
+
+            subject = repertoire['subject']['subject_id']
+            vdjbase_name_to_study_subject[vdjbase_subject] = (study, subject)
+            if vdjbase_subject == 'P27_I1':
+                print(f"Mapping VDJbase name: {vdjbase_subject} to study/subject: {study} / {subject}")
+
+        else:
+            print(f"Cannot determine VDJbase name from repertoire ID: {repertoire_id}")
+
+    return vdjbase_name_to_study_subject
+
+
+def dump_studies_in_container(container):
+    print("Studies in container:")
+    for investigation_id, investigation in container.investigations.items():
+        num_participants = len(investigation.participants)
+
+        # Calculate specimen counts per participant
+        specimen_counts = []
+        for participant_id in investigation.participants:
+            # Find life events for this participant
+            life_events = [le.akc_id for le in container['life_events'].values() if le.participant == participant_id]
+            # Count specimens for all life events of this participant
+            participant_specimen_count = 0
+            for sp in container['specimens'].values():
+                if sp.life_event in life_events:
+                    participant_specimen_count += 1
+            specimen_counts.append((container.participants[participant_id].name, participant_specimen_count))
+        
+        if specimen_counts:
+            specimen_counts = [count for name, count in specimen_counts]
+            min_specimens = min(specimen_counts)
+            max_specimens = max(specimen_counts)
+        else:
+            min_specimens = max_specimens = 0
+            
+        print(f"  Study: {investigation.archival_id}  ({investigation.akc_id})")
+        print(f"    Participants: {num_participants}")
+        print(f"    Specimens per participant: min={min_specimens}, max={max_specimens}")
+
+
+def dump_study(container, study_archival_id):
+    """Dump detailed participant and specimen information for a specific study."""
+    # Find the investigation with the matching archival_id
+    target_investigation = None
+    for investigation in container.investigations.values():
+        if investigation.archival_id == study_archival_id:
+            target_investigation = investigation
+            break
+    
+    if not target_investigation:
+        print(f"Study '{study_archival_id}' not found in container")
+        return
+    
+    print(f"\nStudy: {target_investigation.archival_id}")
+    print(f"Name: {target_investigation.name}")
+    print("-" * 80)
+    print(f"{'Participant':<20} {'Specimen ID':<15} {'Specimen Name':<30}")
+    print("-" * 80)
+    
+    for participant_id in target_investigation.participants:
+        participant = container.participants[participant_id]
+        participant_name = participant.name
+        
+        # Find life events for this participant
+        life_events = [le.akc_id for le in container.life_events.values() if le.participant == participant_id]
+        
+        # Find specimens for all life events of this participant
+        participant_specimens = []
+        for sp in container.specimens.values():
+            if sp.life_event in life_events:
+                participant_specimens.append(sp)
+        
+        if participant_specimens:
+            # Print first specimen with participant name
+            first_specimen = participant_specimens[0]
+            print(f"{participant_name:<20} {first_specimen.akc_id:<15} {first_specimen.name or 'N/A':<30}")
+            
+            # Print remaining specimens with empty participant column
+            for specimen in participant_specimens[1:]:
+                print(f"{'':>20} {specimen.akc_id:<15} {specimen.name or 'N/A':<30}")
+        else:
+            # Participant with no specimens
+            print(f"{participant_name:<20} {'No specimens':<15} {'':>30}")
+    
+    print("-" * 80)
 
 
 @click.command()
@@ -23,28 +134,58 @@ def repertoire_transform(cache_id):
     """Transform VDJbase metadata to AK objects."""
 
     if cache_id not in vdjbase_cache_list:
-        print(f"Given cache id: {cache_id} is not in the study list")
+        print(f"Given cache id: {cache_id} is not in the vdjbase_cache_list")
         sys.exit(1)
 
-    study = cache_id
     container = AIRRKnowledgeCommons()
+    vdjbase_name_to_study_subject = {}
 
-    #for filename in ['genomic_metadata_IGH.json', 'genomic_metadata_IGK.json', 'genomic_metadata_IGL.json']:
-    #    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/' + filename, container)
+    for filename in ['genomic_metadata_IGH.json', 'genomic_metadata_IGK.json', 'genomic_metadata_IGL.json']:
+        vdjbase_name_to_study_subject.update(map_vdjbase_name_to_study_subject(vdjbase_data_dir + '/' + cache_id + '/' + filename))
+        container = transform_airr_repertoires(vdjbase_data_dir + '/' + cache_id + '/' + filename, container)
 
-    #for filename in ['airrseq_metadata_IGH.json', 'airrseq_metadata_IGK.json', 'airrseq_metadata_IGL.json', 'airrseq_metadata_TRB.json']:
-    #    container = transform_airr_repertoires(adc_cache_dir + '/' + study + '/' + filename, container)
+    for filename in ['airrseq_metadata_IGH.json', 'airrseq_metadata_IGK.json', 'airrseq_metadata_IGL.json', 'airrseq_metadata_TRB.json']:
+        vdjbase_name_to_study_subject.update(map_vdjbase_name_to_study_subject(vdjbase_data_dir + '/' + cache_id + '/' + filename))
+        container = transform_airr_repertoires(vdjbase_data_dir + '/' + cache_id + '/' + filename, container)
 
-    container = transform_airr_genotypes(vdjbase_data_dir + '/' + study + '/airrseq_all_genotypes.json', container)
-    container = transform_airr_genotypes(vdjbase_data_dir + '/' + study + '/genomic_all_genotypes.json', container)
+    # make a mapping of VDJbase subject ID to investigation, participant
+
+    subj_id_to_participant = {}
+    study_id_to_investigation = {}
+    for investigation_id, investigation in container.investigations.items():
+        for participant_id in investigation.participants:
+            if investigation.archival_id not in study_id_to_investigation:
+                study_id_to_investigation[investigation.archival_id] = investigation_id
+            if investigation_id not in subj_id_to_participant:
+                subj_id_to_participant[investigation_id] = {}
+            participant_name = container['participants'][participant_id].name
+            subj_id_to_participant[investigation_id][participant_name] = participant_id
+
+    # transform vdjbase_name_to_study_subject to refer to akc ids
+    vdjbase_name_to_akc_ids = {}
+    for vdjbase_name, (study_id, subject_id) in vdjbase_name_to_study_subject.items():
+        if study_id in study_id_to_investigation:
+            investigation_id = study_id_to_investigation[study_id]
+            if subject_id in subj_id_to_participant[investigation_id]:
+                participant_id = subj_id_to_participant[investigation_id][subject_id]
+                vdjbase_name_to_akc_ids[vdjbase_name] = (investigation_id, participant_id)
+            else:
+                print(f"Cannot find subject id: {study_id} / {subject_id} in participants for investigation: {investigation_id} ({container['investigations'][investigation_id].archival_id})")
+        else:
+            print(f"Cannot find study id: {study_id} in investigations")
+
+    dump_studies_in_container(container)
+
+    container = transform_airr_genotypes(vdjbase_data_dir + '/' + cache_id + '/airrseq_all_genotypes.json', container)
+    container = transform_airr_genotypes(vdjbase_data_dir + '/' + cache_id + '/genomic_all_genotypes.json', container)
     
-    # output data for just this study
-    directory_name = f'{vdjbase_data_dir}/vdjbase_jsonl/{study}'
+    # output data for just this cache_id
+    directory_name = f'{vdjbase_data_dir}/vdjbase_jsonl/{cache_id}'
     try:
         os.mkdir(directory_name)
     except FileExistsError:
         pass
-    directory_name = f'{vdjbase_data_dir}/vdjbase_tsv/{study}'
+    directory_name = f'{vdjbase_data_dir}/vdjbase_tsv/{cache_id}'
     try:
         os.mkdir(directory_name)
     except FileExistsError:
@@ -59,12 +200,13 @@ def repertoire_transform(cache_id):
             continue
         container_slot = ak_schema_view.get_slot(container_field)
         tname = container_slot.range
-        write_jsonl(container, container_field, f'{vdjbase_data_dir}/vdjbase_jsonl/{study}/{tname}.jsonl')
-        write_csv(container, container_field, f'{vdjbase_data_dir}/vdjbase_tsv/{study}/{tname}.csv')
+        write_jsonl(container, container_field, f'{vdjbase_data_dir}/vdjbase_jsonl/{cache_id}/{tname}.jsonl')
+        write_csv(container, container_field, f'{vdjbase_data_dir}/vdjbase_tsv/{cache_id}/{tname}.csv')
 
     # CSV relationships
-    write_all_relationships(container, f'{vdjbase_data_dir}/vdjbase_tsv/{study}/')
+    write_all_relationships(container, f'{vdjbase_data_dir}/vdjbase_tsv/{cache_id}/')
 
 
 if __name__ == "__main__":
-    repertoire_transform()
+    for cache_id in vdjbase_cache_list:
+        repertoire_transform.callback(cache_id)


### PR DESCRIPTION
We can split this up into two scenarios:

1. Genotype data where the AIRR-seq data resides only in VDJbase.
2. Genotype data where the AIRR-seq data resides in both ADC and VDJbase (though the sequence data has likely been processed differently).

I think we should focus on this latter one as it is can be used for both. In theory, part 1 can split into two steps: 1) use the standard ADC integration to bring in the VDJbase data then 2) use the same part 2 above to bring in genotype data.

The challenge will be to link up the identifiers between the study, subject and genotype. Once we have that worked out, then it will be easier to dig into the details of how the genotype data is represented.

A few studies (not exhaustive) that already exist in ADC that we can use for testing:

- PRJNA300878 (cache: 6508961642208563691-242ac113-0001-012)
- PRJNA509910 (cache: 8575123754278514195-242ac11b-0001-012)
- PRJNA680539 (cache: 6270798281029250580-242ac117-0001-012)